### PR TITLE
Modernize libc string headers and impls

### DIFF
--- a/include/mach/sa/string.h
+++ b/include/mach/sa/string.h
@@ -24,6 +24,7 @@
 #define _MACH_STRING_H_
 
 #include <sys/cdefs.h>
+#include <sys/types.h>
 
 #ifndef NULL
 #define NULL 0
@@ -32,10 +33,12 @@
 __BEGIN_DECLS
 
 __DECL(char *,strdup(const char *s));
+__DECL(char *,strcpy(char *dest, const char *src));
 __DECL(char *,strcat(char *dest, const char *src));
 __DECL(int,strcmp(const char *a, const char *b));
-__DECL(int,strncpy(char *dest, const char *src, int n));
-__DECL(int,strncmp(const char *a, const char *b, int n));
+__DECL(char *,strncpy(char *dest, const char *src, size_t n));
+__DECL(int,strncmp(const char *a, const char *b, size_t n));
+__DECL(size_t,strlen(const char *s));
 
 __DECL(char *,strchr(const char *s, int c));
 __DECL(char *,strrchr(const char *s, int c));
@@ -44,12 +47,12 @@ __DECL(char *,rindex(const char *s, int c));
 __DECL(void *,strstr(const char *haystack, const char *needle));
 
 #ifndef __GNUC__
-__DECL(void *,memcpy(void *to, const void *from, unsigned int n));
+__DECL(void *,memcpy(void *to, const void *from, size_t n));
 #endif
-__DECL(void *,memset(void *to, int ch, unsigned int n));
+__DECL(void *,memset(void *to, int ch, size_t n));
 
-__DECL(void,bcopy(const void *from, void *to, unsigned int n));
-__DECL(void,bzero(void *to, unsigned int n));
+__DECL(void,bcopy(const void *from, void *to, size_t n));
+__DECL(void,bzero(void *to, size_t n));
 
 __END_DECLS
 

--- a/libmach/c/memcmp.c
+++ b/libmach/c/memcmp.c
@@ -38,8 +38,10 @@
  *	contents are identical upto the length of s1.
  */
 
+#include <sys/types.h>
+
 int
-memcmp(const void *s1v, const void *s2v, int size)
+memcmp(const void *s1v, const void *s2v, size_t size)
 {
 	register const char *s1 = s1v, *s2 = s2v;
 	register unsigned int a, b;

--- a/libmach/c/memset.c
+++ b/libmach/c/memset.c
@@ -24,13 +24,13 @@
 #include <sys/types.h>
 
 void *
-memcmp(void *tov, int c, size_t len)
+memset(void *tov, int c, size_t len)
 {
-	register char *to = tov;
+        char *to = tov;
 
-	while (len-- > 0)
-		*to++ = c;
+        while (len-- > 0)
+                *to++ = c;
 
-	return tov;
+        return tov;
 }
 

--- a/libmach/c/strcat.c
+++ b/libmach/c/strcat.c
@@ -22,17 +22,19 @@
  * 
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
- */
+*/
+
+#include <string.h>
 
 char *
-strcat(s, add)
-register char *s, *add;
+strcat(char *s, const char *add)
 {
-register char *ret = s;
+    char *ret = s;
 
-	while(*s) s++;
+    while (*s)
+        s++;
 
-	while(*s++ = *add++) ;
-
-	return ret;
+    while ((*s++ = *add++) != '\0')
+        ;
+    return ret;
 }

--- a/libmach/c/strcpy.c
+++ b/libmach/c/strcpy.c
@@ -33,13 +33,14 @@
  *	is returned.
  */
 
+#include <string.h>
+
 char *
-strcpy(to,from)
-register char *to, *from;
+strcpy(char *to, const char *from)
 {
-register char *ret = to;
+    char *ret = to;
 
-	while(*to++ = *from++);
-
-	return ret;
+    while ((*to++ = *from++) != '\0')
+        ;
+    return ret;
 }

--- a/libmach/c/strlen.c
+++ b/libmach/c/strlen.c
@@ -32,14 +32,15 @@
  *	the terminating null character.
  */
 
-int
-strlen(string)
-    register char *string;
+#include <sys/types.h>
+
+size_t
+strlen(const char *string)
 {
-register char *ret = string;
+    const char *ret = string;
 
-    while (*string++);
-
-    return string - 1 - ret;
+    while (*string++)
+        ;
+    return (size_t)(string - 1 - ret);
 
 }

--- a/libmach/c/strncmp.c
+++ b/libmach/c/strncmp.c
@@ -19,22 +19,23 @@
  */
 
 #include <string.h>
+#include <sys/types.h>
 
 int
-strncmp(const char *s1, const char *s2, int n)
+strncmp(const char *s1, const char *s2, size_t n)
 {
 	while (1)
 	{
-		if (n <= 0)
-			return 0;
+                if (n == 0)
+                        return 0;
 		if (*s1 != *s2)
 			return *s1 - *s2;
 		if (*s1 == 0)
 			return 0;
 
-		s1++;
-		s2++;
-		n--;
+                s1++;
+                s2++;
+                n--;
 	}
 }
 

--- a/libmach/c/strncpy.c
+++ b/libmach/c/strncpy.c
@@ -35,17 +35,18 @@
  *	to the "to" string.
  */
 
+#include <sys/types.h>
+
 char *
-strncpy(to, from, count)
-    register char *to, *from;
-    register int count;
+strncpy(char *to, const char *from, size_t count)
 {
-    register char *ret = to;
+    char *ret = to;
 
-    while (count-- > 0 && (*to++ = *from++));
+    while (count-- > 0 && (*to++ = *from++) != '\0')
+        ;
 
-    while (count-- > 0) 
-	*to++ = '\0';
+    while (count-- > 0)
+        *to++ = '\0';
 
     return ret;
 }

--- a/libmach/c/strstr.c
+++ b/libmach/c/strstr.c
@@ -20,19 +20,20 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 void *strstr(const char *haystack, const char *needle)
 {
-	int hlen = strlen(haystack);
-	int nlen = strlen(needle);
+        size_t hlen = strlen(haystack);
+        size_t nlen = strlen(needle);
 
 	while (hlen >= nlen)
 	{
-		if (!memcmp(haystack, needle, nlen))
-			return (void*)haystack;
+                if (!memcmp(haystack, needle, nlen))
+                        return (void*)haystack;
 
 		haystack++;
-		hlen--;
+                hlen--;
 	}
 	return 0;
 }


### PR DESCRIPTION
## Summary
- refactor `string.h` standalone header to use `size_t`
- modernize libc string functions
- rename old memset stub

## Testing
- `../i386/configure --with-mach4=.. --prefix=/tmp/mach-install`
- `make -j$(nproc)` *(fails: lex missing)*