### PR TITLE
Add POSIX wrappers with EINTR retry logic

### DIFF
--- a/include/mach/sa/sys/socket.h
+++ b/include/mach/sa/sys/socket.h
@@ -1,0 +1,32 @@
+#ifndef _MACH_SA_SYS_SOCKET_H_
+#define _MACH_SA_SYS_SOCKET_H_
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+struct sockaddr {
+unsigned short sa_family;
+char sa_data[14];
+};
+
+struct iovec {
+void *iov_base;
+int iov_len;
+};
+
+struct msghdr {
+void *msg_name;
+int msg_namelen;
+struct iovec *msg_iov;
+int msg_iovlen;
+void *msg_accrights;
+int msg_accrightslen;
+};
+
+__BEGIN_DECLS
+int accept(int, struct sockaddr *, int *);
+int sendmsg(int, const struct msghdr *, int);
+int recvmsg(int, struct msghdr *, int);
+__END_DECLS
+
+#endif /* _MACH_SA_SYS_SOCKET_H_ */

--- a/include/px.h
+++ b/include/px.h
@@ -1,0 +1,13 @@
+#ifndef _PX_H_
+#define _PX_H_
+
+#include <sys/types.h>
+#include <sys/socket.h>
+
+ssize_t px_pread(int fd, void *buf, size_t nbyte, off_t offset);
+ssize_t px_pwrite(int fd, const void *buf, size_t nbyte, off_t offset);
+int px_sendmsg(int sockfd, const struct msghdr *msg, int flags);
+int px_recvmsg(int sockfd, struct msghdr *msg, int flags);
+int px_accept(int sockfd, struct sockaddr *addr, int *addrlen);
+
+#endif /* _PX_H_ */

--- a/libmach/posix_retry.c
+++ b/libmach/posix_retry.c
@@ -1,0 +1,54 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+ssize_t
+px_pread(int fd, void *buf, size_t nbyte, off_t offset)
+{
+	ssize_t rc;
+	do {
+	 rc = pread(fd, buf, nbyte, offset);
+	} while (rc < 0 && errno == EINTR);
+	return rc;
+}
+
+ssize_t
+px_pwrite(int fd, const void *buf, size_t nbyte, off_t offset)
+{
+	ssize_t rc;
+	do {
+	 rc = pwrite(fd, buf, nbyte, offset);
+	} while (rc < 0 && errno == EINTR);
+	return rc;
+}
+
+int
+px_sendmsg(int sockfd, const struct msghdr *msg, int flags)
+{
+	int rc;
+	do {
+	 rc = sendmsg(sockfd, msg, flags);
+	} while (rc < 0 && errno == EINTR);
+	return rc;
+}
+
+int
+px_recvmsg(int sockfd, struct msghdr *msg, int flags)
+{
+	int rc;
+	do {
+	 rc = recvmsg(sockfd, msg, flags);
+	} while (rc < 0 && errno == EINTR);
+	return rc;
+}
+
+int
+px_accept(int sockfd, struct sockaddr *addr, int *addrlen)
+{
+	int rc;
+	do {
+	 rc = accept(sockfd, addr, addrlen);
+	} while (rc < 0 && errno == EINTR);
+	return rc;
+}


### PR DESCRIPTION
## Summary
- add minimal socket header for standalone POSIX use
- add header declaring new px_* wrappers
- implement px_pread, px_pwrite, px_sendmsg, px_recvmsg, px_accept with EINTR retry loops

## Testing
- `git diff --cached --stat`