### PR TITLE
Fix MIG header guard warnings

### DIFF
--- a/i386/include/mach/machine/vm_types.h
+++ b/i386/include/mach/machine/vm_types.h
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1992,1991,1990,1989,1988 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
@@ -31,11 +31,11 @@
  *	Header file for VM data types.  I386 version.
  */
 
-#ifndef	_MACHINE_VM_TYPES_H_
-#define _MACHINE_VM_TYPES_H_	1
+#ifndef _MACHINE_VM_TYPES_H_
+#define _MACHINE_VM_TYPES_H_ 1
 
-#ifdef	ASSEMBLER
-#else	ASSEMBLER
+#ifdef ASSEMBLER
+#else /* ASSEMBLER */
 
 /*
  * A natural_t is the type for the native
@@ -48,7 +48,7 @@
  * a port in user space as an integer and
  * in kernel space as a pointer.
  */
-typedef unsigned int	natural_t;
+typedef unsigned int natural_t;
 
 /*
  * An integer_t is the signed counterpart
@@ -57,15 +57,15 @@ typedef unsigned int	natural_t;
  * other types in a machine-independent
  * way.
  */
-typedef int		integer_t;
+typedef int integer_t;
 
 #ifndef _POSIX_SOURCE
 
 /*
  * An int32 is an integer that is at least 32 bits wide
  */
-typedef int		int32;
-typedef unsigned int	uint32;
+typedef int int32;
+typedef unsigned int uint32;
 
 #endif /* _POSIX_SOURCE */
 
@@ -73,36 +73,35 @@ typedef unsigned int	uint32;
  * A vm_offset_t is a type-neutral pointer,
  * e.g. an offset into a virtual memory space.
  */
-typedef	natural_t	vm_offset_t;
+typedef natural_t vm_offset_t;
 
 /*
  * A vm_size_t is the proper type for e.g.
  * expressing the difference between two
  * vm_offset_t entities.
  */
-typedef	natural_t	vm_size_t;
+typedef natural_t vm_size_t;
 
 /*
  * These types are _exactly_ as wide as indicated in their names.
  */
-typedef signed char		signed8_t;
-typedef signed short		signed16_t;
-typedef signed long		signed32_t;
-typedef signed long long	signed64_t;
-typedef unsigned char		unsigned8_t;
-typedef unsigned short		unsigned16_t;
-typedef unsigned long		unsigned32_t;
-typedef unsigned long long	unsigned64_t;
-typedef float			float32_t;
-typedef double			float64_t;
+typedef signed char signed8_t;
+typedef signed short signed16_t;
+typedef signed long signed32_t;
+typedef signed long long signed64_t;
+typedef unsigned char unsigned8_t;
+typedef unsigned short unsigned16_t;
+typedef unsigned long unsigned32_t;
+typedef unsigned long long unsigned64_t;
+typedef float float32_t;
+typedef double float64_t;
 
-#endif	/* ASSEMBLER */
+#endif /* ASSEMBLER */
 
 /*
  * If composing messages by hand (please dont)
  */
 
-#define	MACH_MSG_TYPE_INTEGER_T	MACH_MSG_TYPE_INTEGER_32
+#define MACH_MSG_TYPE_INTEGER_T MACH_MSG_TYPE_INTEGER_32
 
-#endif	/* _MACHINE_VM_TYPES_H_ */
-
+#endif /* _MACHINE_VM_TYPES_H_ */

--- a/mig/alloc.h
+++ b/mig/alloc.h
@@ -1,34 +1,34 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1991,1990 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
- * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS 
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie the
  * rights to redistribute these changes.
  */
 
-#ifndef	_ALLOC_H
-#define	_ALLOC_H
+#ifndef _ALLOC_H
+#define _ALLOC_H
 
 extern char *malloc();
 extern char *calloc();
 extern void free();
 
-#endif	_ALLOC_H
+#endif /* _ALLOC_H */

--- a/mig/error.c
+++ b/mig/error.c
@@ -1,101 +1,89 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1991,1990 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
- * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS 
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie the
  * rights to redistribute these changes.
  */
 
-#include <stdio.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-#include "global.h"
 #include "error.h"
+#include "global.h"
 #include "lexxer.h"
 
 static const char *program;
 int errors = 0;
 
-void
-fatal(const char *format, ...)
-{
-    va_list pvar;
-    va_start(pvar, format);
-    fprintf(stderr, "%s: fatal: ", program);
-    (void) vfprintf(stderr, format, pvar);
+void fatal(const char *format, ...) {
+  va_list pvar;
+  va_start(pvar, format);
+  fprintf(stderr, "%s: fatal: ", program);
+  (void)vfprintf(stderr, format, pvar);
+  fprintf(stderr, "\n");
+  va_end(pvar);
+  exit(1);
+}
+
+void warn(const char *format, ...) {
+  va_list pvar;
+  va_start(pvar, format);
+  if (!BeQuiet && (errors == 0)) {
+    fprintf(stderr, "\"%s\", line %d: warning: ", inname, lineno - 1);
+    (void)vfprintf(stderr, format, pvar);
     fprintf(stderr, "\n");
-    va_end(pvar);
-    exit(1);
+  }
+  va_end(pvar);
 }
 
-void
-warn(const char *format, ...)
-{
-    va_list pvar;
-    va_start(pvar, format);
-    if (!BeQuiet && (errors == 0))
-    {
-	fprintf(stderr, "\"%s\", line %d: warning: ", inname, lineno-1);
-	(void) vfprintf(stderr, format, pvar);
-	fprintf(stderr, "\n");
-    }
-    va_end(pvar);
+void error(const char *format, ...) {
+  va_list pvar;
+  va_start(pvar, format);
+  fprintf(stderr, "\"%s\", line %d: ", inname, lineno - 1);
+  (void)vfprintf(stderr, format, pvar);
+  fprintf(stderr, "\n");
+  va_end(pvar);
+  errors++;
 }
 
-void
-error(const char *format, ...)
-{
-    va_list pvar;
-    va_start(pvar, format);
-    fprintf(stderr, "\"%s\", line %d: ", inname, lineno-1);
-    (void) vfprintf(stderr, format, pvar);
-    fprintf(stderr, "\n");
-    va_end(pvar);
-    errors++;
-}
-
-const char *
-unix_error_string(int error_num)
-{
-    static char buffer[256];
-    const char *error_mess;
+const char *unix_error_string(int error_num) {
+  static char buffer[256];
+  const char *error_mess;
 
 #ifdef HAVE_STRERROR
-    error_mess = strerror (error_num);
+  error_mess = strerror(error_num);
 #else
-    extern int sys_nerr;
-    extern char *sys_errlist[];
+  extern int sys_nerr;
+  extern char *sys_errlist[];
 
-    if ((0 <= error_num) && (error_num < sys_nerr))
-	error_mess = sys_errlist[error_num];
-    else
-	error_mess = "strange errno";
+  if ((0 <= error_num) && (error_num < sys_nerr))
+    error_mess = sys_errlist[error_num];
+  else
+    error_mess = "strange errno";
 #endif
 
-    sprintf(buffer, "%s (%d)", error_mess, error_num);
-    return buffer;
+  sprintf(buffer, "%s (%d)", error_mess, error_num);
+  return buffer;
 }
 
-void
-set_program_name(const char *name)
-{
-    program = name;
-}
+void set_program_name(const char *name) { program = name; }

--- a/mig/migcom.c
+++ b/mig/migcom.c
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1993,1991,1990 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
- * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS 
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie the
  * rights to redistribute these changes.
  */
@@ -28,10 +28,10 @@
  *	Switches are;
  *		-[v,Q]  verbose or not quiet:  prints out type
  *			and routine information as mig runs.
- *		-[V,q]  not verbose or quiet : don't print 
+ *		-[V,q]  not verbose or quiet : don't print
  *			information during compilation
  *			(this is the default)
- *		-[r,R]  do or don't use rpc calls instead of 
+ *		-[r,R]  do or don't use rpc calls instead of
  *			send/receive pairs. Default is -r.
  *		-[s,S]	generate symbol table or not:  generate a
  *			table of rpc-name, number, routine triplets
@@ -67,232 +67,205 @@
  *	header.c user.c and server.c are called sequentially. These
  *	do some code generation directly and also call the routines
  *	in utils.c for common (parameterized) code generation.
- *	
+ *
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "error.h"
-#include "lexxer.h"
 #include "global.h"
+#include "lexxer.h"
 #include "write.h"
 
 extern int yyparse();
 static FILE *myfopen(const char *name, const char *mode);
 
-static void
-parseArgs(int argc, char **argv)
-{
-    while (--argc > 0)
-	if ((++argv)[0][0] == '-') 
-	{
-	    switch (argv[0][1]) 
-	    {
-	      case 'q':
-		BeQuiet = TRUE;
-		break;
-	      case 'Q':
-		BeQuiet = FALSE;
-		break;
-	      case 'v':
-		BeVerbose = TRUE;
-		break;
-	      case 'V':
-		BeVerbose = FALSE;
-		break;
-	      case 'r':
-		UseMsgRPC = TRUE;
-		break;
-	      case 'R':
-		UseMsgRPC = FALSE;
-		break;
-	      case 's':
-		if (streql(argv[0], "-server"))
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-			fatal("missing name for -server option");
-		    ServerFileName = strmake(argv[0]);
-		}
-		else if (streql(argv[0], "-sheader"))
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-		      fatal ("missing name for -sheader option");
-		    ServerHeaderFileName = strmake(argv[0]);
-		}
- 		else if (streql(argv[0], "-subrprefix"))
- 		  {
- 		    --argc; ++argv;
- 		    if (argc == 0)
- 		      fatal ("missing string for -subrprefix option");
- 		    SubrPrefix = strmake(argv[0]);
- 		  }
-		else
-		    GenSymTab = TRUE;
-		break;
-	      case 'S':
-	        GenSymTab = FALSE;
-		break;
-	      case 'i':
-		if (streql(argv[0], "-iheader"))
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-			fatal("missing name for -iheader option");
-		    InternalHeaderFileName = strmake(argv[0]);
-		}
-		else
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-			fatal("missing prefix for -i option");
-		    UserFilePrefix = strmake(argv[0]);
-		}
-		break;
-	      case 'u':
-		if (streql(argv[0], "-user"))
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-			fatal("missing name for -user option");
-		    UserFileName = strmake(argv[0]);
-		}
-		else
-		    fatal("unknown flag: '%s'", argv[0]);
-		break;
-	      case 'h':
-		if (streql(argv[0], "-header"))
-		{
-		    --argc; ++argv;
-		    if (argc == 0)
-			fatal("missing name for -header option");
-		    UserHeaderFileName = strmake(argv[0]);
-		}
-		else
-		    fatal("unknown flag: '%s'", argv[0]);
-		break;
- 	      case 'p':
- 		if (streql(argv[0], "-prefix"))
- 		  {
- 		    if (--argc == 0)
- 		      fatal ("missing string for -prefix option");
- 		    RoutinePrefix = strmake(*++argv);
- 		  }
-  		break;
-	      default:
-		fatal("unknown flag: '%s'", argv[0]);
-		/*NOTREACHED*/
-	    }
-	}
-	else
-	    fatal("bad argument: '%s'", *argv);
+static void parseArgs(int argc, char **argv) {
+  while (--argc > 0)
+    if ((++argv)[0][0] == '-') {
+      switch (argv[0][1]) {
+      case 'q':
+        BeQuiet = TRUE;
+        break;
+      case 'Q':
+        BeQuiet = FALSE;
+        break;
+      case 'v':
+        BeVerbose = TRUE;
+        break;
+      case 'V':
+        BeVerbose = FALSE;
+        break;
+      case 'r':
+        UseMsgRPC = TRUE;
+        break;
+      case 'R':
+        UseMsgRPC = FALSE;
+        break;
+      case 's':
+        if (streql(argv[0], "-server")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing name for -server option");
+          ServerFileName = strmake(argv[0]);
+        } else if (streql(argv[0], "-sheader")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing name for -sheader option");
+          ServerHeaderFileName = strmake(argv[0]);
+        } else if (streql(argv[0], "-subrprefix")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing string for -subrprefix option");
+          SubrPrefix = strmake(argv[0]);
+        } else
+          GenSymTab = TRUE;
+        break;
+      case 'S':
+        GenSymTab = FALSE;
+        break;
+      case 'i':
+        if (streql(argv[0], "-iheader")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing name for -iheader option");
+          InternalHeaderFileName = strmake(argv[0]);
+        } else {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing prefix for -i option");
+          UserFilePrefix = strmake(argv[0]);
+        }
+        break;
+      case 'u':
+        if (streql(argv[0], "-user")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing name for -user option");
+          UserFileName = strmake(argv[0]);
+        } else
+          fatal("unknown flag: '%s'", argv[0]);
+        break;
+      case 'h':
+        if (streql(argv[0], "-header")) {
+          --argc;
+          ++argv;
+          if (argc == 0)
+            fatal("missing name for -header option");
+          UserHeaderFileName = strmake(argv[0]);
+        } else
+          fatal("unknown flag: '%s'", argv[0]);
+        break;
+      case 'p':
+        if (streql(argv[0], "-prefix")) {
+          if (--argc == 0)
+            fatal("missing string for -prefix option");
+          RoutinePrefix = strmake(*++argv);
+        }
+        break;
+      default:
+        fatal("unknown flag: '%s'", argv[0]);
+        /*NOTREACHED*/
+      }
+    } else
+      fatal("bad argument: '%s'", *argv);
 }
 
-void
-main(int argc, char **argv)
-{
-    FILE *uheader, *server, *user;
-    FILE *iheader, *sheader;
+void main(int argc, char **argv) {
+  FILE *uheader, *server, *user;
+  FILE *iheader, *sheader;
 
-    set_program_name("mig");
-    parseArgs(argc, argv);
-    init_global();
-    init_type();
+  set_program_name("mig");
+  parseArgs(argc, argv);
+  init_global();
+  init_type();
 
-    LookNormal();
-    (void) yyparse();
+  LookNormal();
+  (void)yyparse();
 
-    if (errors > 0)
-	exit(1);
+  if (errors > 0)
+    exit(1);
 
-    more_global();
+  more_global();
 
-    uheader = myfopen(UserHeaderFileName, "w");
-    if (!UserFilePrefix)
-	user = myfopen(UserFileName, "w");
-    server = myfopen(ServerFileName, "w");
-    if (ServerHeaderFileName)
-	sheader = myfopen(ServerHeaderFileName, "w");
-    if (IsKernelServer)
-    {
-	iheader = myfopen(InternalHeaderFileName, "w");
-    }
+  uheader = myfopen(UserHeaderFileName, "w");
+  if (!UserFilePrefix)
+    user = myfopen(UserFileName, "w");
+  server = myfopen(ServerFileName, "w");
+  if (ServerHeaderFileName)
+    sheader = myfopen(ServerHeaderFileName, "w");
+  if (IsKernelServer) {
+    iheader = myfopen(InternalHeaderFileName, "w");
+  }
 
-    if (BeVerbose)
-    {
-	printf("Writing %s ... ", UserHeaderFileName);
-	fflush(stdout);
+  if (BeVerbose) {
+    printf("Writing %s ... ", UserHeaderFileName);
+    fflush(stdout);
+  }
+  WriteUserHeader(uheader, StatementList);
+  fclose(uheader);
+  if (ServerHeaderFileName) {
+    if (BeVerbose) {
+      printf("done.\nWriting %s ...", ServerHeaderFileName);
+      fflush(stdout);
     }
-    WriteUserHeader(uheader, StatementList);
-    fclose(uheader);
-    if (ServerHeaderFileName)
-    {
-	if (BeVerbose)
-	{
-	    printf ("done.\nWriting %s ...", ServerHeaderFileName);
-	    fflush (stdout);
-	}
-	WriteServerHeader(sheader, StatementList);
-	fclose(sheader);
+    WriteServerHeader(sheader, StatementList);
+    fclose(sheader);
+  }
+  if (IsKernelServer) {
+    if (BeVerbose) {
+      printf("done.\nWriting %s ... ", InternalHeaderFileName);
+      fflush(stdout);
     }
-    if (IsKernelServer)
-    {
-	if (BeVerbose)
-	{
-	    printf("done.\nWriting %s ... ", InternalHeaderFileName);
-	    fflush(stdout);
-	}
-	WriteInternalHeader(iheader, StatementList);
-	fclose(iheader);
+    WriteInternalHeader(iheader, StatementList);
+    fclose(iheader);
+  }
+  if (UserFilePrefix) {
+    if (BeVerbose) {
+      printf("done.\nWriting individual user files ... ");
+      fflush(stdout);
     }
-    if (UserFilePrefix)
-    {
-	if (BeVerbose)
-	{
-	    printf("done.\nWriting individual user files ... ");
-	    fflush(stdout);
-	}
-	WriteUserIndividual(StatementList);
+    WriteUserIndividual(StatementList);
+  } else {
+    if (BeVerbose) {
+      printf("done.\nWriting %s ... ", UserFileName);
+      fflush(stdout);
     }
-    else
-    {
-	if (BeVerbose)
-	{
-	    printf("done.\nWriting %s ... ", UserFileName);
-	    fflush(stdout);
-	}
-	WriteUser(user, StatementList);
-	fclose(user);
-    }
-    if (BeVerbose)
-    {
-	printf("done.\nWriting %s ... ", ServerFileName);
-	fflush(stdout);
-    }
-    WriteServer(server, StatementList);
-    fclose(server);
-    if (BeVerbose)
-	printf("done.\n");
+    WriteUser(user, StatementList);
+    fclose(user);
+  }
+  if (BeVerbose) {
+    printf("done.\nWriting %s ... ", ServerFileName);
+    fflush(stdout);
+  }
+  WriteServer(server, StatementList);
+  fclose(server);
+  if (BeVerbose)
+    printf("done.\n");
 
-    exit(0);
+  exit(0);
 }
 
-static FILE *
-myfopen(const char *name, const char *mode)
-{
-    const char *realname;
-    FILE *file;
-    extern int errno;
+static FILE *myfopen(const char *name, const char *mode) {
+  const char *realname;
+  FILE *file;
+  extern int errno;
 
-    if (name == strNULL)
-	realname = "/dev/null";
-    else
-	realname = name;
+  if (name == strNULL)
+    realname = "/dev/null";
+  else
+    realname = name;
 
-    file = fopen(realname, mode);
-    if (file == NULL)
-	fatal("fopen(%s): %s", realname, unix_error_string(errno));
+  file = fopen(realname, mode);
+  if (file == NULL)
+    fatal("fopen(%s): %s", realname, unix_error_string(errno));
 
-    return file;
+  return file;
 }

--- a/mig/statement.h
+++ b/mig/statement.h
@@ -1,60 +1,57 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1991,1990 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
- * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS 
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie the
  * rights to redistribute these changes.
  */
 
-#ifndef	_STATEMENT_H
-#define	_STATEMENT_H
+#ifndef _STATEMENT_H
+#define _STATEMENT_H
 
 #include "routine.h"
 
-typedef enum statement_kind
-{
-    skRoutine,
-    skImport,
-    skUImport,
-    skSImport,
-    skRCSDecl,
+typedef enum statement_kind {
+  skRoutine,
+  skImport,
+  skUImport,
+  skSImport,
+  skRCSDecl,
 } statement_kind_t;
 
-typedef struct statement
-{
-    statement_kind_t stKind;
-    struct statement *stNext;
-    union
-    {
-	/* when stKind == skRoutine */
-	routine_t *_stRoutine;
-	/* when stKind == skImport, skUImport, skSImport */
-	const_string_t _stFileName;
-    } data;
+typedef struct statement {
+  statement_kind_t stKind;
+  struct statement *stNext;
+  union {
+    /* when stKind == skRoutine */
+    routine_t *_stRoutine;
+    /* when stKind == skImport, skUImport, skSImport */
+    const_string_t _stFileName;
+  } data;
 } statement_t;
 
-#define	stRoutine	data._stRoutine
-#define	stFileName	data._stFileName
+#define stRoutine data._stRoutine
+#define stFileName data._stFileName
 
-#define stNULL		((statement_t *) 0)
+#define stNULL ((statement_t *)0)
 
 /* stNext will be initialized to put the statement in the list */
 extern statement_t *stAlloc(void);
@@ -62,4 +59,4 @@ extern statement_t *stAlloc(void);
 /* list of statements, in order they occur in the .defs file */
 extern statement_t *StatementList;
 
-#endif	_STATEMENT_H
+#endif /* _STATEMENT_H */


### PR DESCRIPTION
## Summary
- address compiler warnings and modernize header guards
- include `stdlib.h` for exit declarations
- clean up assembler preprocessor directive style

## Testing
- `make -r` *(fails: lex not found)*
- `.codex/setup.sh` *(fails: package retrieval via apt-get)*