### PR TITLE
Add Doxygen comments for message queue and screen helpers

### DIFF
--- a/kernel/chips/sfb_misc.c
+++ b/kernel/chips/sfb_misc.c
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
@@ -33,101 +33,88 @@
  */
 
 #include <sfb.h>
-#if	(NSFB > 0)
+#if (NSFB > 0)
 #include <platforms.h>
 
 /*
  * NOTE: This driver relies heavily on the pm one, as well as the cfb.
  */
 
-#include <device/device_types.h>
-#include <chips/screen_defs.h>
 #include <chips/pm_defs.h>
-typedef pm_softc_t	sfb_softc_t;
+#include <chips/screen_defs.h>
+#include <device/device_types.h>
+typedef pm_softc_t sfb_softc_t;
 
 #include <chips/bt459.h>
-#define	bt459		cursor_registers
+#define bt459 cursor_registers
 
-#ifdef	DECSTATION
+#ifdef DECSTATION
 #include <mips/PMAX/pmagb_ba.h>
 #endif
 
-#ifdef	FLAMINGO
-#include <mips/PMAX/pmagb_ba.h>		/* XXXX */
+#ifdef FLAMINGO
+#include <mips/PMAX/pmagb_ba.h> /* Use PMAX mapping on Flamingo */
 #endif
 
-/*
- * Initialize color map, for kernel use
+/**
+ * @brief Initialize the color map for kernel use.
  */
-#define	sfb_init_colormap		cfb_init_colormap
+#define sfb_init_colormap cfb_init_colormap
+/**
+ * @brief Position the hardware cursor.
+ *
+ * @param regs Register map for the BT459 RAMDAC.
+ * @param x    Horizontal position.
+ * @param y    Vertical position.
+ */
+sfb_pos_cursor(bt459_regmap_t *regs, int x, int y) {
+  bt459_pos_cursor(regs, x + 368 - 219, y + 37 - 34);
+}
+/**
+ * @brief Convert a small cursor sprite to a large one.
+ */
+#define sfb_small_cursor_to_large cfb_small_cursor_to_large
 
-/*
- * Position cursor
+/**
+ * @brief Device specific set status handler.
  */
-sfb_pos_cursor(
-	bt459_regmap_t	*regs,
-	int		x,
-	int		y)
-{
-	bt459_pos_cursor( regs, x + 368 - 219, y + 37 - 34);
+#define sfb_set_status cfb_set_status
+/**
+ * @brief Initialize the SFB hardware.
+ *
+ * @param sfb Pointer to the SFB software context.
+ */
+sfb_init_screen(sfb_softc_t *sfb) {
+  bt459_init(sfb->bt459, sfb->bt459 + (SFB_OFFSET_RESET - SFB_OFFSET_BT459),
+             4 /* 4:1 MUX */);
+}
+/**
+ * @brief Restore hardware state after the X server exits.
+ *
+ * @param sc Screen device context.
+ */
+sfb_soft_reset(screen_softc_t sc) {
+  sfb_softc_t *sfb = (sfb_softc_t *)sc->hw_state;
+  user_info_t *up = sc->up;
+  extern cursor_sprite_t dc503_default_cursor;
+
+  /* Restore parameters in mapped structure. */
+  pm_init_screen_params(sc, up);
+  up->row = up->max_row - 1;
+
+  /* Magic hardware fields. */
+  up->dev_dep_2.pm.x26 = 2;
+  up->dev_dep_1.pm.x18 = (short *)2;
+
+  /* Restore RAMDAC chip to default state. */
+  sfb_init_screen(sfb);
+
+  /* Load kernel's cursor sprite. */
+  sfb_small_cursor_to_large(up, dc503_default_cursor);
+  bt459_cursor_sprite(sfb->bt459, up->dev_dep_2.pm.cursor_sprite);
+
+  /* Color map and cursor color. */
+  sfb_init_colormap(sc);
 }
 
-/*
- * Large viz small cursor
- */
-#define	sfb_small_cursor_to_large	cfb_small_cursor_to_large
-
-/*
- * Device-specific set status
- */
-#define sfb_set_status			cfb_set_status
-
-/*
- * Hardware initialization
- */
-sfb_init_screen(
-	sfb_softc_t *sfb)
-{
-	bt459_init( sfb->bt459,
-		    sfb->bt459 + (SFB_OFFSET_RESET - SFB_OFFSET_BT459),
-		    4 /* 4:1 MUX */);
-}
-
-/*
- * Do what's needed when X exits
- */
-sfb_soft_reset(
-	screen_softc_t	sc)
-{
-	sfb_softc_t	*sfb = (sfb_softc_t*) sc->hw_state;
-	user_info_t	*up =  sc->up;
-	extern cursor_sprite_t	dc503_default_cursor;
-
-	/*
-	 * Restore params in mapped structure
-	 */
-	pm_init_screen_params(sc,up);
-	up->row = up->max_row - 1;
-
-	up->dev_dep_2.pm.x26 = 2; /* you do not want to know */
-	up->dev_dep_1.pm.x18 = (short*)2;
-
-	/*
-	 * Restore RAMDAC chip to default state
-	 */
-	sfb_init_screen(sfb);
-
-	/*
-	 * Load kernel's cursor sprite: just use the same pmax one
-	 */
-	sfb_small_cursor_to_large(up, dc503_default_cursor);
-	bt459_cursor_sprite(sfb->bt459, up->dev_dep_2.pm.cursor_sprite);
-
-	/*
-	 * Color map and cursor color
-	 */
-	sfb_init_colormap(sc);
-}
-
-
-#endif	(NSFB > 0)
+#endif(NSFB > 0)

--- a/kernel/ipc/ipc_mqueue.h
+++ b/kernel/ipc/ipc_mqueue.h
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1991,1990,1989 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
@@ -31,48 +31,67 @@
  *	Definitions for message queues.
  */
 
-#ifndef	_IPC_IPC_MQUEUE_H_
+#ifndef _IPC_IPC_MQUEUE_H_
 #define _IPC_IPC_MQUEUE_H_
 
-#include <mach/message.h>
+#include <ipc/ipc_kmsg.h>
+#include <ipc/ipc_thread.h>
 #include <kern/assert.h>
 #include <kern/lock.h>
 #include <kern/macro_help.h>
-#include <ipc/ipc_kmsg.h>
-#include <ipc/ipc_thread.h>
+#include <mach/message.h>
 
+/**
+ * @brief Internal message queue structure.
+ */
 typedef struct ipc_mqueue {
-	decl_simple_lock_data(, imq_lock_data)
-	struct ipc_kmsg_queue imq_messages;
-	struct ipc_thread_queue imq_threads;
+  decl_simple_lock_data(, imq_lock_data) struct ipc_kmsg_queue imq_messages;
+  struct ipc_thread_queue imq_threads;
 } *ipc_mqueue_t;
 
-#define	IMQ_NULL		((ipc_mqueue_t) 0)
+#define IMQ_NULL ((ipc_mqueue_t)0)
 
-#define	imq_lock_init(mq)	simple_lock_init(&(mq)->imq_lock_data)
-#define	imq_lock(mq)		simple_lock(&(mq)->imq_lock_data)
-#define	imq_lock_try(mq)	simple_lock_try(&(mq)->imq_lock_data)
-#define	imq_unlock(mq)		simple_unlock(&(mq)->imq_lock_data)
+#define imq_lock_init(mq) simple_lock_init(&(mq)->imq_lock_data)
+#define imq_lock(mq) simple_lock(&(mq)->imq_lock_data)
+#define imq_lock_try(mq) simple_lock_try(&(mq)->imq_lock_data)
+#define imq_unlock(mq) simple_unlock(&(mq)->imq_lock_data)
 
-extern void
-ipc_mqueue_init(/* ipc_mqueue_t */);
+/**
+ * @brief Initialize a message queue.
+ *
+ * @param mq Queue to initialize.
+ */
+extern void ipc_mqueue_init(/* ipc_mqueue_t */);
 
-extern void
-ipc_mqueue_move(/* ipc_mqueue_t, ipc_mqueue_t, ipc_port_t */);
+/**
+ * @brief Move all messages from one queue to another.
+ */
+extern void ipc_mqueue_move(/* ipc_mqueue_t, ipc_mqueue_t, ipc_port_t */);
 
-extern void
-ipc_mqueue_changed(/* ipc_mqueue_t, mach_msg_return_t */);
+/**
+ * @brief Notify threads waiting on a queue of state changes.
+ */
+extern void ipc_mqueue_changed(/* ipc_mqueue_t, mach_msg_return_t */);
 
-extern mach_msg_return_t
-ipc_mqueue_send(/* ipc_kmsg_t, mach_msg_option_t, mach_msg_timeout_t */);
+/**
+ * @brief Send a message on a queue.
+ */
+/**
+ * @brief Send a message on a queue.
+ */
+extern mach_msg_return_t ipc_mqueue_send(
+    /* ipc_kmsg_t, mach_msg_option_t, mach_msg_timeout_t */);
 
-#define	IMQ_NULL_CONTINUE	((void (*)()) 0)
+#define IMQ_NULL_CONTINUE ((void (*)())0)
 
-extern mach_msg_return_t
-ipc_mqueue_receive(/* ipc_mqueue_t, mach_msg_option_t,
-		      mach_msg_size_t, mach_msg_timeout_t,
-		      boolean_t, void (*)(),
-		      ipc_kmsg_t *, mach_port_seqno_t * */);
+/**
+ * @brief Receive a message from a queue.
+ */
+extern mach_msg_return_t ipc_mqueue_receive(
+    /* ipc_mqueue_t, mach_msg_option_t,
+       mach_msg_size_t, mach_msg_timeout_t,
+       boolean_t, void (*)(),
+       ipc_kmsg_t *, mach_port_seqno_t * */);
 
 /*
  *	extern void
@@ -81,28 +100,27 @@ ipc_mqueue_receive(/* ipc_mqueue_t, mach_msg_option_t,
  *	Unfortunately, to avoid warnings/lint about unused variables
  *	when assertions are turned off, we need two versions of this.
  */
+/**
+ * @brief Macro to send a message regardless of queue state.
+ */
 
-#include <kern/assert.h>
+#if MACH_ASSERT
 
-#if	MACH_ASSERT
+#define ipc_mqueue_send_always(kmsg)                                           \
+  MACRO_BEGIN                                                                  \
+  mach_msg_return_t mr;                                                        \
+                                                                               \
+  mr = ipc_mqueue_send((kmsg), MACH_SEND_ALWAYS, MACH_MSG_TIMEOUT_NONE);       \
+  assert(mr == MACH_MSG_SUCCESS);                                              \
+  MACRO_END
 
-#define	ipc_mqueue_send_always(kmsg)					\
-MACRO_BEGIN								\
-	mach_msg_return_t mr;						\
-									\
-	mr = ipc_mqueue_send((kmsg), MACH_SEND_ALWAYS,			\
-			     MACH_MSG_TIMEOUT_NONE);			\
-	assert(mr == MACH_MSG_SUCCESS);					\
-MACRO_END
+#else MACH_ASSERT
 
-#else	MACH_ASSERT
+#define ipc_mqueue_send_always(kmsg)                                           \
+  MACRO_BEGIN(void)                                                            \
+  ipc_mqueue_send((kmsg), MACH_SEND_ALWAYS, MACH_MSG_TIMEOUT_NONE);            \
+  MACRO_END
 
-#define	ipc_mqueue_send_always(kmsg)					\
-MACRO_BEGIN								\
-	(void) ipc_mqueue_send((kmsg), MACH_SEND_ALWAYS,		\
-			       MACH_MSG_TIMEOUT_NONE);			\
-MACRO_END
+#endif /* MACH_ASSERT */
 
-#endif	/* MACH_ASSERT */
-
-#endif	/* _IPC_IPC_MQUEUE_H_ */
+#endif /* _IPC_IPC_MQUEUE_H_ */


### PR DESCRIPTION
## Summary
- document framebuffer helpers in sfb_misc.c
- clean up includes and add Doxygen comments in ipc_mqueue.h
- apply clang-format
- run project setup

## Testing
- `bash setup.sh > /tmp/setup.log`


------
https://chatgpt.com/codex/tasks/task_e_684697d497c483318708330c6632eeb4