### PR TITLE
Improve setup script diagnostics

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-##\file setup.sh
-##\brief Setup script for the OpenMach development environment.
+## \file setup.sh
+## \brief Setup script for the OpenMach development environment.
+##
+## This script installs all prerequisites for building and
+## developing OpenMach. It logs every command with maximum
+## verbosity so failures can be diagnosed easily.
 
 set -euo pipefail
 
@@ -9,7 +13,11 @@ LOGFILE="setup.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 set -x
 
-# Packages required for development
+# Avoid interactive prompts when installing packages.
+export DEBIAN_FRONTEND=noninteractive
+
+# Packages required for development.
+# Each package is attempted with apt-get and falls back to pip or npm.
 packages=(
 	build-essential clang clang-tools lld lldb llvm clang-18 bison ccache buildcache
 	cmake make automake autoconf libtool pkg-config
@@ -23,36 +31,38 @@ packages=(
 	llvm-bolt polly
 )
 
-# Update package sources
-sudo apt-get update
+# Update package sources.
+sudo apt-get update -y
 sudo apt-get dist-upgrade -y
 
-# Install a package using apt-get, then pip, then npm
+# Install a package using apt-get, then pip, then npm.
+## \param pkg Package name to install.
 install_pkg() {
 	local pkg="$1"
 	echo "Installing $pkg with apt-get"
-	if sudo apt-get install -y "$pkg"; then
+	if sudo apt-get install -y --no-install-recommends "$pkg"; then
 		echo "$pkg installed via apt-get"
-		return
+		return 0
 	fi
 
 	echo "$pkg failed with apt-get, trying pip"
 	if pip install "$pkg"; then
 		echo "$pkg installed via pip"
-		return
+		return 0
 	fi
 
 	echo "$pkg failed with pip, trying npm"
 	if npm install -g "$pkg"; then
 		echo "$pkg installed via npm"
-		return
+		return 0
 	fi
 
 	echo "Could not install $pkg using apt, pip, or npm"
+	return 1
 }
 
 for pkg in "${packages[@]}"; do
-	install_pkg "$pkg"
+	install_pkg "$pkg" || true
 done
 
 # Configure build cache directories for modern compilation
@@ -63,3 +73,5 @@ elif command -v ccache >/dev/null; then
 	ccache --set-config=cache_dir="$PWD/ccache"
 	ccache -z
 fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add detailed Doxygen comments to setup.sh
- avoid interactive apt prompts
- retry package install via pip or npm
- write a final message when setup finishes

## Testing
- `shellcheck setup.sh`
- `sudo bash ./setup.sh` *(fails: interrupted during apt-get)*

------
https://chatgpt.com/codex/tasks/task_e_684697cef5488331bb9fffd493763abc