### PR TITLE
Modernize header prototypes

### DIFF
--- a/kernel/ipc/ipc_notify.h
+++ b/kernel/ipc/ipc_notify.h
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1991,1990,1989 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
@@ -31,42 +31,72 @@
  *	Declarations of notification-sending functions.
  */
 
-#ifndef	_IPC_IPC_NOTIFY_H_
+#ifndef _IPC_IPC_NOTIFY_H_
 #define _IPC_IPC_NOTIFY_H_
 
 #include <mach_ipc_compat.h>
 
-extern void
-ipc_notify_init();
+/**
+ * Initialize templates for all notification messages.
+ */
+void ipc_notify_init(void);
 
-extern void
-ipc_notify_port_deleted(/* ipc_port_t, mach_port_t */);
+/**
+ * Send a port deleted notification.
+ *
+ * @param port  The destination port holding a send-once right.
+ * @param name  The name of the port that was deleted.
+ */
+void ipc_notify_port_deleted(ipc_port_t port, mach_port_t name);
 
-extern void
-ipc_notify_msg_accepted(/* ipc_port_t, mach_port_t */);
+/**
+ * Send a message accepted notification.
+ *
+ * @param port  Destination port with a send-once right.
+ * @param name  The name of the port that accepted a message.
+ */
+void ipc_notify_msg_accepted(ipc_port_t port, mach_port_t name);
 
-extern void
-ipc_notify_port_destroyed(/* ipc_port_t, ipc_port_t */);
+/**
+ * Notify that a port was destroyed.
+ *
+ * @param port   Destination port with a send-once right.
+ * @param right  Receive right prepared for transport.
+ */
+void ipc_notify_port_destroyed(ipc_port_t port, ipc_port_t right);
 
-extern void
-ipc_notify_no_senders(/* ipc_port_t, mach_port_mscount_t */);
+/**
+ * Notify that a port has no more senders.
+ *
+ * @param port     Destination port with a send-once right.
+ * @param mscount  The make-send count at the time of notification.
+ */
+void ipc_notify_no_senders(ipc_port_t port, mach_port_mscount_t mscount);
 
-extern void
-ipc_notify_send_once(/* ipc_port_t */);
+/**
+ * Send a send-once notification.
+ *
+ * @param port  Destination port holding a send-once right.
+ */
+void ipc_notify_send_once(ipc_port_t port);
 
-extern void
-ipc_notify_dead_name(/* ipc_port_t, mach_port_t */);
+/**
+ * Notify that a send right has become a dead name.
+ *
+ * @param port  Destination port with a send-once right.
+ * @param name  The dead name.
+ */
+void ipc_notify_dead_name(ipc_port_t port, mach_port_t name);
 
-#if	MACH_IPC_COMPAT
+#if MACH_IPC_COMPAT
+/** Compatibility notification for port deletion using a send right. */
+void ipc_notify_port_deleted_compat(ipc_port_t port, mach_port_t name);
 
-extern void
-ipc_notify_port_deleted_compat(/* ipc_port_t, mach_port_t */);
+/** Compatibility notification for message acceptance using a send right. */
+void ipc_notify_msg_accepted_compat(ipc_port_t port, mach_port_t name);
 
-extern void
-ipc_notify_msg_accepted_compat(/* ipc_port_t, mach_port_t */);
+/** Compatibility notification for port destruction using a send right. */
+void ipc_notify_port_destroyed_compat(ipc_port_t port, ipc_port_t right);
 
-extern void
-ipc_notify_port_destroyed_compat(/* ipc_port_t, ipc_port_t */);
-
-#endif	MACH_IPC_COMPAT
-#endif	_IPC_IPC_NOTIFY_H_
+#endif /* MACH_IPC_COMPAT */
+#endif _IPC_IPC_NOTIFY_H_

--- a/kernel/kern/task.h
+++ b/kernel/kern/task.h
@@ -1,25 +1,25 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1993-1988 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
+ *
  * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
@@ -31,27 +31,27 @@
  *
  */
 
-#ifndef	_KERN_TASK_H_
+#ifndef _KERN_TASK_H_
 #define _KERN_TASK_H_
 
-#include <norma_task.h>
 #include <fast_tas.h>
 #include <net_atm.h>
+#include <norma_task.h>
 
-#include <mach/boolean.h>
-#include <mach/port.h>
-#include <mach/time_value.h>
-#include <mach/mach_param.h>
-#include <mach/task_info.h>
 #include <kern/kern_types.h>
 #include <kern/lock.h>
-#include <kern/queue.h>
 #include <kern/pc_sample.h>
 #include <kern/processor.h>
+#include <kern/queue.h>
 #include <kern/syscall_emulation.h>
+#include <mach/boolean.h>
+#include <mach/mach_param.h>
+#include <mach/port.h>
+#include <mach/task_info.h>
+#include <mach/time_value.h>
 #include <vm/vm_map.h>
 
-#if	NET_ATM
+#if NET_ATM
 typedef struct nw_ep_owned {
   unsigned int ep;
   struct nw_ep_owned *next;
@@ -59,125 +59,115 @@ typedef struct nw_ep_owned {
 #endif
 
 struct task {
-	/* Synchronization/destruction information */
-	decl_simple_lock_data(,lock)	/* Task's lock */
-	int		ref_count;	/* Number of references to me */
-	boolean_t	active;		/* Task has not been terminated */
+  /* Synchronization/destruction information */
+  decl_simple_lock_data(, lock) /* Task's lock */
+      int ref_count;            /* Number of references to me */
+  boolean_t active;             /* Task has not been terminated */
 
-	/* Miscellaneous */
-	vm_map_t	map;		/* Address space description */
-	queue_chain_t	pset_tasks;	/* list of tasks assigned to pset */
-	int		suspend_count;	/* Internal scheduling only */
+  /* Miscellaneous */
+  vm_map_t map;             /* Address space description */
+  queue_chain_t pset_tasks; /* list of tasks assigned to pset */
+  int suspend_count;        /* Internal scheduling only */
 
-	/* Thread information */
-	queue_head_t	thread_list;	/* list of threads */
-	int		thread_count;	/* number of threads */
-	processor_set_t	processor_set;	/* processor set for new threads */
-	boolean_t	may_assign;	/* can assigned pset be changed? */
-	boolean_t	assign_active;	/* waiting for may_assign */
+  /* Thread information */
+  queue_head_t thread_list;      /* list of threads */
+  int thread_count;              /* number of threads */
+  processor_set_t processor_set; /* processor set for new threads */
+  boolean_t may_assign;          /* can assigned pset be changed? */
+  boolean_t assign_active;       /* waiting for may_assign */
 
-	/* User-visible scheduling information */
-	int		user_stop_count;	/* outstanding stops */
-	int		priority;		/* for new threads */
+  /* User-visible scheduling information */
+  int user_stop_count; /* outstanding stops */
+  int priority;        /* for new threads */
 
-	/* Statistics */
-	time_value_t	total_user_time;
-				/* total user time for dead threads */
-	time_value_t	total_system_time;
-				/* total system time for dead threads */
+  /* Statistics */
+  time_value_t total_user_time;
+  /* total user time for dead threads */
+  time_value_t total_system_time;
+  /* total system time for dead threads */
 
-	/* IPC structures */
-	decl_simple_lock_data(, itk_lock_data)
-	struct ipc_port *itk_self;	/* not a right, doesn't hold ref */
-	struct ipc_port *itk_sself;	/* a send right */
-	struct ipc_port *itk_exception;	/* a send right */
-	struct ipc_port *itk_bootstrap;	/* a send right */
-	struct ipc_port *itk_registered[TASK_PORT_REGISTER_MAX];
-					/* all send rights */
+  /* IPC structures */
+  decl_simple_lock_data(, itk_lock_data) struct ipc_port
+      *itk_self;                  /* not a right, doesn't hold ref */
+  struct ipc_port *itk_sself;     /* a send right */
+  struct ipc_port *itk_exception; /* a send right */
+  struct ipc_port *itk_bootstrap; /* a send right */
+  struct ipc_port *itk_registered[TASK_PORT_REGISTER_MAX];
+  /* all send rights */
 
-	struct ipc_space *itk_space;
+  struct ipc_space *itk_space;
 
-	/* User space system call emulation support */
-	struct 	eml_dispatch	*eml_dispatch;
+  /* User space system call emulation support */
+  struct eml_dispatch *eml_dispatch;
 
-	sample_control_t pc_sample;
+  sample_control_t pc_sample;
 
-#if	NORMA_TASK
-	long		child_node;	/* if != -1, node for new children */
-#endif	/* NORMA_TASK */
+#if NORMA_TASK
+  long child_node; /* if != -1, node for new children */
+#endif             /* NORMA_TASK */
 
-#if	FAST_TAS
-#define TASK_FAST_TAS_NRAS	8	
-	vm_offset_t	fast_tas_base[TASK_FAST_TAS_NRAS];
-	vm_offset_t	fast_tas_end[TASK_FAST_TAS_NRAS];
-#endif	/* FAST_TAS */
+#if FAST_TAS
+#define TASK_FAST_TAS_NRAS 8
+  vm_offset_t fast_tas_base[TASK_FAST_TAS_NRAS];
+  vm_offset_t fast_tas_end[TASK_FAST_TAS_NRAS];
+#endif /* FAST_TAS */
 
-#if	NET_ATM
-	nw_ep_owned_t   nw_ep_owned;
-#endif	/* NET_ATM */
+#if NET_ATM
+  nw_ep_owned_t nw_ep_owned;
+#endif /* NET_ATM */
 };
 
-#define task_lock(task)		simple_lock(&(task)->lock)
-#define task_unlock(task)	simple_unlock(&(task)->lock)
+#define task_lock(task) simple_lock(&(task)->lock)
+#define task_unlock(task) simple_unlock(&(task)->lock)
 
-#define	itk_lock_init(task)	simple_lock_init(&(task)->itk_lock_data)
-#define	itk_lock(task)		simple_lock(&(task)->itk_lock_data)
-#define	itk_unlock(task)	simple_unlock(&(task)->itk_lock_data)
+#define itk_lock_init(task) simple_lock_init(&(task)->itk_lock_data)
+#define itk_lock(task) simple_lock(&(task)->itk_lock_data)
+#define itk_unlock(task) simple_unlock(&(task)->itk_lock_data)
 
 /*
  *	Exported routines/macros
  */
 
-extern kern_return_t	task_create(
-	task_t		parent_task,
-	boolean_t	inherit_memory,
-	task_t		*child_task);
-extern kern_return_t	task_terminate(
-	task_t		task);
-extern kern_return_t	task_suspend(
-	task_t		task);
-extern kern_return_t	task_resume(
-	task_t		task);
-extern kern_return_t	task_threads(
-	task_t		task,
-	thread_array_t	*thread_list,
-	natural_t	*count);
-extern kern_return_t	task_info(
-	task_t		task,
-	int		flavor,
-	task_info_t	task_info_out,
-	natural_t	*task_info_count);
-extern kern_return_t	task_get_special_port(
-	task_t		task,
-	int		which,
-	struct ipc_port	**portp);
-extern kern_return_t	task_set_special_port(
-	task_t		task,
-	int		which,
-	struct ipc_port	*port);
-extern kern_return_t	task_assign(
-	task_t		task,
-	processor_set_t	new_pset,
-	boolean_t	assign_threads);
-extern kern_return_t	task_assign_default(
-	task_t		task,
-	boolean_t	assign_threads);
+/**
+ * Create a new task.
+ *
+ * @param parent_task     Parent task from which to inherit resources.
+ * @param inherit_memory  Whether to inherit the parent's address space.
+ * @param child_task      Resulting task reference.
+ */
+extern kern_return_t task_create(task_t parent_task, boolean_t inherit_memory,
+                                 task_t *child_task);
+extern kern_return_t task_terminate(task_t task);
+extern kern_return_t task_suspend(task_t task);
+extern kern_return_t task_resume(task_t task);
+extern kern_return_t task_threads(task_t task, thread_array_t *thread_list,
+                                  natural_t *count);
+extern kern_return_t task_info(task_t task, int flavor,
+                               task_info_t task_info_out,
+                               natural_t *task_info_count);
+extern kern_return_t task_get_special_port(task_t task, int which,
+                                           struct ipc_port **portp);
+extern kern_return_t task_set_special_port(task_t task, int which,
+                                           struct ipc_port *port);
+extern kern_return_t task_assign(task_t task, processor_set_t new_pset,
+                                 boolean_t assign_threads);
+extern kern_return_t task_assign_default(task_t task, boolean_t assign_threads);
 
 /*
  *	Internal only routines
  */
 
-extern void		task_init();
-extern void		task_reference();
-extern void		task_deallocate();
-extern kern_return_t	task_hold();
-extern kern_return_t	task_dowait();
-extern kern_return_t	task_release();
-extern kern_return_t	task_halt();
+extern void task_init();
+extern void task_reference();
+extern void task_deallocate();
+extern kern_return_t task_hold();
+extern kern_return_t task_dowait();
+extern kern_return_t task_release();
+extern kern_return_t task_halt();
 
-extern kern_return_t	task_suspend_nowait();
-extern task_t		kernel_task_create();
+extern kern_return_t task_suspend_nowait();
+extern task_t kernel_task_create();
 
-extern task_t	kernel_task;
+extern task_t kernel_task;
 
-#endif	_KERN_TASK_H_
+#endif _KERN_TASK_H_


### PR DESCRIPTION
## Summary
- add Doxygen-style documentation to ipc_notify.h and task_create prototype
- modernize function declarations with explicit parameters

## Testing
- `./setup.sh` *(failed: apt-get upgrade requires network access)*


------
https://chatgpt.com/codex/tasks/task_e_684697d609108331bb091bcdbcc1a785

## Summary by Sourcery

Modernize header declarations and documentation in ipc_notify.h and task.h by converting old-style prototypes to ANSI C with explicit parameters, adding Doxygen-style comments, and standardizing formatting.

Enhancements:
- Convert K&R-style function declarations in task.h and ipc_notify.h to ANSI C prototypes with named parameters
- Standardize preprocessor directives, include ordering, and macro formatting across headers

Documentation:
- Add Doxygen-style documentation to ipc_notify.h notification routines
- Annotate task_create and related task functions with descriptive parameter comments

Chores:
- Reformat license comment blocks and whitespace for consistent indentation
- Clean up guard macros and align file header formatting